### PR TITLE
Update main.py

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -700,7 +700,6 @@ if __name__ == "__main__":
             "target": "pytorch_lightning.loggers.WandbLogger",
             "params": {
                 "name": nowname,
-                "entity": "matereal-diffuser",
                 "project": "matfuse",
                 "save_dir": logdir,
                 "offline": opt.debug,


### PR DESCRIPTION
Wandb will error out script with 

```
wandb: ERROR Error while calling W&B API: entity matereal-diffuser not found during upsertBucket (<Response [404]>)
```

default entity removed to fix

docs say entity will be set by default to username of api runner