### PR TITLE
Fix: KeyError: 'vqmodel' and wandb.errors.Error: You must call wandb.init() before wandb.log()

### DIFF
--- a/src/ldm/models/autoencoder.py
+++ b/src/ldm/models/autoencoder.py
@@ -393,7 +393,7 @@ class VQModelMulti(VQModel):
             self.init_from_ckpt(ckpt_path, ignore_keys=[])
 
     def init_from_ckpt(self, path, ignore_keys=list()):
-        sd = torch.load(path, map_location="cpu")["vqmodel"]
+        sd = torch.load(path, map_location="cpu")
         keys = list(sd.keys())
         for k in keys:
             for ik in ignore_keys:

--- a/src/main.py
+++ b/src/main.py
@@ -399,8 +399,6 @@ class ImageLogger(Callback):
         self.log_images_kwargs = log_images_kwargs if log_images_kwargs else {}
         self.log_first_step = log_first_step
 
-        wandb.init(project=os.environ.get("WANDB_PROJECT", "matfuse"), entity=os.environ.get("WANDB_ENTITY"))
-
     @rank_zero_only
     def _wandb(self, pl_module, images, batch_idx, split):
         if "conditions" in images:
@@ -613,7 +611,8 @@ if __name__ == "__main__":
     #           target: importpath
     #           params:
     #               key: value
-
+    wandb.init(project=os.environ.get("WANDB_PROJECT", "matfuse"), entity=os.environ.get("WANDB_ENTITY"))
+    
     now = datetime.datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
 
     # add cwd for convenience and to make classes in this file available when


### PR DESCRIPTION
Fix for 

Autoencoder loading error:
```
KeyError: 'vqmodel'
```
------------------------------------------

WANDB Error: 
```
wandb.errors.Error: You must call wandb.init() before wandb.log()
```